### PR TITLE
update Ubuntu 22.04 image to the latest

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -56,8 +56,8 @@ variable "data_vol_iops" {
 variable "image_name" {
   description = "Name of AMI image to use."
   type        = string
-  default     = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20220810"
-  /* Use: aws ec2 describe-images --filters 'Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-focal-20.04*' */
+  default     = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240801"
+  /* Use: aws ec2 describe-images --filters 'Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-jammy-22.04*' */
 }
 
 variable "image_owner" {


### PR DESCRIPTION
Previous image was removed from AWS:
```
│ Error: Your query returned no results. Please change your search criteria and try again.
│
│   with module.eth2_fallback.data.aws_ami.ubuntu,
│   on .terraform/modules/eth2_fallback/main.tf line 16, in data "aws_ami" "ubuntu":
│   16: data "aws_ami" "ubuntu" {
```

```sh
❯ aws --profile aws-status-eth2 ec2 describe-images --filters 'Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-jammy-22.04*' | grep "\"Name\"" | grep ubuntu-jammy-22.04-amd64-server- | awk -F\/ '{print $4}' | awk -F\" '{print $1}' | sort
ubuntu-jammy-22.04-amd64-server-20220901
ubuntu-jammy-22.04-amd64-server-20220901-47489723-7305-4e22-8b22-b0d57054f216
...
ubuntu-jammy-22.04-amd64-server-20240801
ubuntu-jammy-22.04-amd64-server-20240801-47489723-7305-4e22-8b22-b0d57054f216
```

Or maybe it's time to start switching to 24.04?